### PR TITLE
Include access context in document retrieval

### DIFF
--- a/document.go
+++ b/document.go
@@ -292,7 +292,7 @@ func (_Documents) List(input *DocumentsListInput, offset, limit int64) ([]*Docum
 
 	tbl := DocTypes.docStorName(input.DocTypeID)
 	q := `
-	SELECT docs.id, docs.path, docs.group_id, docs.docstate_id, dsm.name, docs.ctime, docs.title
+	SELECT docs.id, docs.path, docs.ac_id, docs.group_id, docs.docstate_id, dsm.name, docs.ctime, docs.title
 	FROM ` + tbl + ` docs
 	JOIN wf_docstates_master dsm ON dsm.id = docs.docstate_id
 	`
@@ -355,7 +355,7 @@ func (_Documents) List(input *DocumentsListInput, offset, limit int64) ([]*Docum
 	for rows.Next() {
 		var elem Document
 		var title sql.NullString
-		err = rows.Scan(&elem.ID, &elem.Path, &elem.Group, &elem.State.ID, &elem.State.Name, &elem.Ctime, &title)
+		err = rows.Scan(&elem.ID, &elem.Path, &elem.AccCtx.ID, &elem.Group, &elem.State.ID, &elem.State.Name, &elem.Ctime, &title)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +381,7 @@ func (_Documents) Get(otx *sql.Tx, dtype DocTypeID, id DocumentID) (*Document, e
 	tbl := DocTypes.docStorName(dtype)
 	var elem Document
 	q := `
-	SELECT docs.path, docs.group_id, docs.ctime, docs.title, docs.data, docs.docstate_id, dsm.name
+	SELECT docs.path, docs.ac_id, docs.group_id, docs.ctime, docs.title, docs.data, docs.docstate_id, dsm.name
 	FROM ` + tbl + ` AS docs
 	JOIN wf_docstates_master dsm ON docs.docstate_id = dsm.id
 	WHERE docs.id = ?
@@ -393,7 +393,7 @@ func (_Documents) Get(otx *sql.Tx, dtype DocTypeID, id DocumentID) (*Document, e
 	} else {
 		row = otx.QueryRow(q, id)
 	}
-	err := row.Scan(&elem.Path, &elem.Group, &elem.Ctime, &elem.Title, &elem.Data, &elem.State.ID, &elem.State.Name)
+	err := row.Scan(&elem.Path, &elem.AccCtx.ID, &elem.Group, &elem.Ctime, &elem.Title, &elem.Data, &elem.State.ID, &elem.State.Name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Remove useless members of `AccessContext`, by returning appropriate
  data directly in queries for groups and group roles.